### PR TITLE
fix: required "to" date on projects form

### DIFF
--- a/src/resources/projects/components/EditForm/index.tsx
+++ b/src/resources/projects/components/EditForm/index.tsx
@@ -122,7 +122,6 @@ const EditForm: FC<PropsWithChildren<EditFormProps>> = ({
               }}
             />
             <DateInput
-              validate={required()}
               source={addSource<ProjectRequest>('to')}
               sx={{ flex: 1, mr: 1 }}
               format={(value) => {


### PR DESCRIPTION
### Your checklist for this pull request

🚨 Things to verify before creating pull request

- [ ] Every commit follow the semver format [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Pull request title must also have the semver format since using squash will be the only commit that will appear in the changelog.

### Description

"to" date is not required anymore on projects form

## Changes

- [x] `to` date is not a required field anymore on create and/or update projects form

## Trello Ticket

["to" date should be an optional value on projects form (create/update)](https://trello.com/c/xj3raADR/130-to-date-should-be-an-optional-value-on-projects-form-create-update)

❤️ Thank you!
