### PR TITLE
feat: remove next button in add experience modal

### DIFF
--- a/src/resources/professionals/components/ProjectsSection/Steps.tsx
+++ b/src/resources/professionals/components/ProjectsSection/Steps.tsx
@@ -392,11 +392,6 @@ const StepsDialog: FC<PropsWithChildren<StepsProps>> = ({
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
         {activeStep !== 0 && <Button onClick={handleBack}>Back</Button>}
-        {activeStep !== steps.length - 1 ? (
-          <Button onClick={handleNext}>Next</Button>
-        ) : (
-          <></>
-        )}
       </DialogActions>
     </Dialog>
   );


### PR DESCRIPTION
When user navigating to "add experience" modal, he won't see the "next" button.
He will go forward by selecting one of the options.


[Trello ticket](https://trello.com/c/cBizcm2H/13-add-experience-modal-remove-next-button)
