### PR TITLE
feat: remove already added projects from list

### DIFF
--- a/src/resources/professionals/components/ProjectsSection/Steps.tsx
+++ b/src/resources/professionals/components/ProjectsSection/Steps.tsx
@@ -45,12 +45,14 @@ type StepsProps = {
   open: boolean;
   handleClose: () => void;
   professionalId: string;
+  ownProjectsId: string[];
 };
 
 const StepsDialog: FC<PropsWithChildren<StepsProps>> = ({
   open,
   handleClose,
   professionalId,
+  ownProjectsId,
 }) => {
   const [activeStep, setActiveStep] = useState(0);
   const [vairixProject, setVairixProject] = useState(false);
@@ -317,7 +319,9 @@ const StepsDialog: FC<PropsWithChildren<StepsProps>> = ({
                     data-testid="search-project"
                     value={selectedProject}
                     onChange={handleOnChangeAutocomplete}
-                    options={allProjects}
+                    options={allProjects.filter(
+                      (project) => !ownProjectsId.includes(project.id),
+                    )}
                     getOptionLabel={handleGetOptionLabel}
                     renderInput={handleRenderInputAutocomplete}
                   />

--- a/src/resources/professionals/components/ProjectsSection/index.tsx
+++ b/src/resources/professionals/components/ProjectsSection/index.tsx
@@ -94,6 +94,7 @@ const ProjectsSection: FC<ProjectsSectionProps> = ({
       {availableProjects && (
         <StepsDialog
           professionalId={professionalId || ''}
+          ownProjectsId={projects.map((p) => p.project.id)}
           open={isOpen}
           handleClose={handleClose}
         ></StepsDialog>


### PR DESCRIPTION
### Description

User won't be able to select projects that he already chose.

### Trello Ticket

[Trello ticket](https://trello.com/c/oKuau4aN/15-add-experience-modal-vairix-remove-currently-added-projects-from-select-list)


