### PR TITLE
feat: add validation to technologies, methodologies, and skills

### DIFF
--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -33,9 +33,11 @@ const Dialog: FC<PropsWithChildren<DialogProps>> = ({
         <Button data-testid="dialog-cancel" onClick={close} color="primary">
           {closeText}
         </Button>
-        <Button data-testid="dialog-add" onClick={submit} color="primary">
-          {submitText}
-        </Button>
+        {submitText && (
+          <Button data-testid="dialog-add" onClick={submit} color="primary">
+            {submitText}
+          </Button>
+        )}
       </DialogActions>
     </MuiDialog>
   );

--- a/src/resources/professionals/components/AddAttributesSection/AddProfessionalAttribute.tsx
+++ b/src/resources/professionals/components/AddAttributesSection/AddProfessionalAttribute.tsx
@@ -233,6 +233,14 @@ const AddProfessionalAttribute: FC<AddProfessionalAttributeProps> = ({
     [],
   );
 
+  const createdAttributes = useMemo(
+    () => allOptions.map((attr) => attr.name.toLowerCase()),
+    [allOptions],
+  );
+  const isCreatedAttribute = createdAttributes.includes(
+    dialogValue.toLowerCase(),
+  );
+
   return (
     <>
       <Autocomplete
@@ -252,8 +260,12 @@ const AddProfessionalAttribute: FC<AddProfessionalAttributeProps> = ({
       />
       <Dialog
         closeText="Cancel"
-        submitText="Create"
-        dialogTitle={`Create new ${attributeTypeName}`}
+        submitText={!isCreatedAttribute ? 'Create' : ''}
+        dialogTitle={
+          !isCreatedAttribute
+            ? `Create new ${attributeTypeName}`
+            : `Attribute already created`
+        }
         close={handleCloseDialog}
         isOpen={isOpen}
         submit={createNewAttributeType}


### PR DESCRIPTION
### Description

When editing professionals, user won't be able to add technologies that already exist.

### Trello Ticket

[Trello ticket](https://trello.com/c/qYCthj07/6-edit-professional-screen-add-validation-to-technologies-methodologies-skills-pills)
