### PR TITLE
feat: add confirmation modal when exit edit mode

### DIFF
--- a/src/resources/professionals/Edit.tsx
+++ b/src/resources/professionals/Edit.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import {
   Edit,
   useEditController,
@@ -6,15 +6,17 @@ import {
   useRedirect,
   useUpdate,
 } from 'react-admin';
+import Dialog from 'components/Dialog';
 import { ProfessionalRequest, ProfessionalResponse } from 'types';
 import VisibilityIcon from '@mui/icons-material/Visibility';
-import { Button, Box } from '@mui/material';
+import { Button, Box, Typography } from '@mui/material';
 import EditForm from './components/EditForm';
 import { Loading, SectionTitle } from 'components/ui';
 import { ACTIONS, RESOURCES } from 'api/resources';
 import { TEXTS } from 'constants/index';
 
 export const ProfessionalEdit: FC = () => {
+  const [isExitConfirmationOpen, setIsExitConfirmationOpen] = useState(false);
   const notify = useNotify();
   const redirect = useRedirect();
   const { record, isLoading } = useEditController<ProfessionalResponse>();
@@ -47,37 +49,56 @@ export const ProfessionalEdit: FC = () => {
   };
 
   return (
-    <Edit
-      title={TEXTS.PROFESSIONALS_TITLE}
-      redirect={ACTIONS.SHOW}
-      component="div"
-      actions={false}
-    >
-      <EditForm
-        save={handleSave}
-        professionalId={id}
-        projects={projects}
-        attributes={attributes}
+    <>
+      <Edit
+        title={TEXTS.PROFESSIONALS_TITLE}
+        redirect={ACTIONS.SHOW}
+        component="div"
+        actions={false}
       >
-        <Box
+        <EditForm
+          save={handleSave}
+          professionalId={id}
+          projects={projects}
+          attributes={attributes}
+        >
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              mb: 2,
+            }}
+          >
+            <SectionTitle title={TEXTS.EDIT_PROFESSIONAL} />
+            <Box>
+              <Button
+                startIcon={<VisibilityIcon />}
+                variant="outlined"
+                onClick={() => setIsExitConfirmationOpen(true)}
+              >
+                {TEXTS.SHOW_PROFESSIONAL}
+              </Button>
+            </Box>
+          </Box>
+        </EditForm>
+      </Edit>
+      <Dialog
+        closeText="Cancel"
+        submitText="OK"
+        dialogTitle="Are you sure you want to exit edit mode?"
+        close={() => setIsExitConfirmationOpen(false)}
+        isOpen={isExitConfirmationOpen}
+        submit={handleRedirectShow}
+      >
+        <Typography
           sx={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            mb: 2,
+            fontWeight: 'bold',
+            textAlign: 'center',
           }}
         >
-          <SectionTitle title={TEXTS.EDIT_PROFESSIONAL} />
-          <Box>
-            <Button
-              startIcon={<VisibilityIcon />}
-              variant="outlined"
-              onClick={handleRedirectShow}
-            >
-              {TEXTS.SHOW_PROFESSIONAL}
-            </Button>
-          </Box>
-        </Box>
-      </EditForm>
-    </Edit>
+          Changes will be lost
+        </Typography>
+      </Dialog>
+    </>
   );
 };

--- a/src/resources/professionals/components/EditForm/index.tsx
+++ b/src/resources/professionals/components/EditForm/index.tsx
@@ -69,6 +69,7 @@ const EditForm: FC<PropsWithChildren<EditFormProps>> = ({
 
   return (
     <SimpleForm
+      warnWhenUnsavedChanges
       component={Box}
       onSubmit={handleSave}
       toolbar={


### PR DESCRIPTION

### Description

Please describe your pull request.

### Trello Ticket

[Trello ticket](https://trello.com/c/UD5qQ9yC/11-edit-professional-screen-add-discard-changes-confirmation-modal)

